### PR TITLE
Add Nix flake dev environment

### DIFF
--- a/.agents/task_url.txt
+++ b/.agents/task_url.txt
@@ -1,0 +1,1 @@
+https://chatgpt.com/codex/tasks/task_e_UNKNOWN

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+agents-workflow/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # zk-wars-website
 The zk-wars.blocksense.network web-site
+
+## Development Environment
+
+This project uses **Nix flakes** and **direnv** to provide a reproducible development shell. After installing [direnv](https://direnv.net/) and enabling the hook in your shell, simply allow the `.envrc` file:
+
+```bash
+cd zk-wars-website
+direnv allow
+```
+
+This will automatically enter a Nix shell containing Node.js and the Playwright browsers needed for the testing workflow described in `docs/TESTING.md`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735651292,
+        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "zk-wars website development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.nodejs
+            pkgs.playwright-driver
+            pkgs.git
+            pkgs.jq
+          ];
+          shellHook = ''
+            export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver}/share/playwright-browsers
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- provide a Nix flake with Node.js and Playwright browsers
- set up direnv integration
- document the new dev environment
- store the task URL

## Testing
- `nix flake check`
- `nix develop -c node --version`

------
https://chatgpt.com/codex/tasks/task_e_684059d534248329a002e63f3d3e54fe