### PR TITLE
Add Cloudflare publish workflow

### DIFF
--- a/.agents/tasks/2025/06/05-0352-publish-cf-pages.txt
+++ b/.agents/tasks/2025/06/05-0352-publish-cf-pages.txt
@@ -1,0 +1,8 @@
+Add a simple `just publish` target that will publish the static web-site
+in the Cloudflare Pages platform.
+
+Create a MAINTAINERS.md file that will provide instructions for how to set
+up the user account in Cloudflare and what environment variables must be
+specified when running the `just publish` command.
+
+Make sure that direnv load ENV variables from a user-supplied .env file.

--- a/.envrc
+++ b/.envrc
@@ -2,4 +2,5 @@
 if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
+dotenv_if_exists
 use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .direnv/
+.env

--- a/Justfile
+++ b/Justfile
@@ -11,3 +11,6 @@ test:
 
 lint:
  eslint src
+
+publish: build
+ wrangler pages deploy build --project-name $CF_PAGES_PROJECT --branch ${CF_PAGES_BRANCH:-main}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,22 @@
+# Maintainers Guide
+
+This project deploys the static site to **Cloudflare Pages**.
+
+## Cloudflare Setup
+
+1. Sign in to Cloudflare and create a new Pages project (e.g. `zk-wars`).
+2. Generate an API token with **Pages:Edit** permission and note your **Account ID**.
+3. Save the following environment variables in a `.env` file at the repository root:
+
+```
+CF_PAGES_PROJECT=<project-name>
+CF_ACCOUNT_ID=<your-account-id>
+CLOUDFLARE_API_TOKEN=<api-token>
+CF_PAGES_BRANCH=main
+```
+
+`direnv` automatically loads variables from `.env` when you enter the shell.
+
+## Publishing
+
+Run `just publish` to build the site and deploy it to Cloudflare Pages.

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
             pkgs.jq
             pkgs.just
             pkgs.nodePackages.eslint
+            pkgs.nodePackages.wrangler
           ];
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver}/share/playwright-browsers


### PR DESCRIPTION
## Summary
- add `just publish` that deploys to Cloudflare Pages
- load optional `.env` variables in direnv
- supply wrangler in the Nix dev shell
- document Cloudflare setup in `MAINTAINERS.md`
- ignore user `.env` files in git

## Testing
- `nix develop -c just test`
- `nix develop -c just lint`


------
https://chatgpt.com/codex/tasks/task_e_68411476da488329b5bd2de3ba5307b4