### PR TITLE
Add skip option and new benchmarks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,3 +14,6 @@ lint:
 
 publish: build
  wrangler pages deploy build --project-name $CF_PAGES_PROJECT --branch ${CF_PAGES_BRANCH:-main}
+
+gen-example-data ARGS='':
+ node scripts/gen-example-data.js {{ARGS}}

--- a/scripts/gen-example-data.js
+++ b/scripts/gen-example-data.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const dataDir = path.join(__dirname, '..', 'test', 'example-data');
-fs.rmSync(dataDir, { recursive: true, force: true });
+const skipExisting = process.argv.includes('--skip-existing');
+if (!skipExisting) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+}
 fs.mkdirSync(dataDir, { recursive: true });
 
 const toolchains = ['jolt','nexus','risc0','sp1','zkm','zkwasm'];
@@ -26,7 +29,12 @@ const benchmarks = [
   'pedersen-commit',
   'bulletproof-range',
   'edwards-mul',
-  'secp256k1-ecdsa'
+  'secp256k1-ecdsa',
+  'sha3-hash',
+  'chacha20-encryption',
+  'ecc-addition',
+  'fft-transform',
+  'rsa-verification'
 ];
 const baseMeans = {
   'poseidon-hash':5,
@@ -48,7 +56,12 @@ const baseMeans = {
   'pedersen-commit':21,
   'bulletproof-range':22,
   'edwards-mul':23,
-  'secp256k1-ecdsa':24
+  'secp256k1-ecdsa':24,
+  'sha3-hash':25,
+  'chacha20-encryption':26,
+  'ecc-addition':27,
+  'fft-transform':28,
+  'rsa-verification':29
 };
 const systems = [
   {
@@ -85,7 +98,7 @@ const systems = [
       hardwareAcceleration: [{ model: 'NVIDIA RTX 3080', cores: 8704, speed: 1710 }],
       accelerated: true
     },
-    benches: ['poseidon-hash','aes256-encryption','ecc-pairing','sha256-hash','mimc-hash','fibonacci-proof','keccak-hash','blake3-hash','pedersen-commit','bulletproof-range','edwards-mul','secp256k1-ecdsa']
+    benches: ['poseidon-hash','aes256-encryption','ecc-pairing','sha256-hash','mimc-hash','fibonacci-proof','keccak-hash','blake3-hash','pedersen-commit','bulletproof-range','edwards-mul','secp256k1-ecdsa','sha3-hash','chacha20-encryption','ecc-addition','fft-transform','rsa-verification']
   },
   {
     name: 'hpc-cluster',
@@ -110,7 +123,7 @@ const systems = [
       hardwareAcceleration: [{ model: 'Apple M1 GPU', cores: 8, speed: 3200 }],
       accelerated: true
     },
-    benches: ['poseidon-hash','merkle-tree','sha256-hash','rsa-signing','snark-verification','ed25519-signing','keccak-hash','blake3-hash','pedersen-commit','secp256k1-ecdsa']
+    benches: ['poseidon-hash','merkle-tree','sha256-hash','rsa-signing','snark-verification','ed25519-signing','keccak-hash','blake3-hash','pedersen-commit','secp256k1-ecdsa','sha3-hash','chacha20-encryption','ecc-addition','fft-transform','rsa-verification']
   }
 ];
 
@@ -154,6 +167,8 @@ for (const sys of systems) {
       const compileMean = base * factor;
       const proveMean = compileMean * 2;
       const verifyMean = compileMean * 0.75;
+      const file = path.join(benchDir, `${tc}.json`);
+      if (skipExisting && fs.existsSync(file)) continue;
       const json = {
         toolchain: tc,
         benchmarks: [{
@@ -164,7 +179,7 @@ for (const sys of systems) {
         }],
         hardware: sys.specs
       };
-      fs.writeFileSync(path.join(benchDir, `${tc}.json`), JSON.stringify(json, null, 2));
+      fs.writeFileSync(file, JSON.stringify(json, null, 2));
     }
   }
 }

--- a/test/example-data/arm-laptop/chacha20-encryption/jolt.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 324.05,
+        "mean": 32.4,
+        "deviation": 1.62,
+        "min": 30.78,
+        "max": 34.02,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 627.73,
+        "mean": 62.77,
+        "deviation": 3.14,
+        "min": 59.63,
+        "max": 65.91,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 234.06,
+        "mean": 23.41,
+        "deviation": 1.17,
+        "min": 22.24,
+        "max": 24.58,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/chacha20-encryption/nexus.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 305.96,
+        "mean": 30.6,
+        "deviation": 1.53,
+        "min": 29.07,
+        "max": 32.13,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 656.66,
+        "mean": 65.67,
+        "deviation": 3.28,
+        "min": 62.39,
+        "max": 68.95,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 247.88,
+        "mean": 24.79,
+        "deviation": 1.24,
+        "min": 23.55,
+        "max": 26.03,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/chacha20-encryption/risc0.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 313.32,
+        "mean": 31.33,
+        "deviation": 1.57,
+        "min": 29.76,
+        "max": 32.9,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 673.24,
+        "mean": 67.32,
+        "deviation": 3.37,
+        "min": 63.95,
+        "max": 70.69,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 235.04,
+        "mean": 23.5,
+        "deviation": 1.18,
+        "min": 22.32,
+        "max": 24.68,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/chacha20-encryption/sp1.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 328.31,
+        "mean": 32.83,
+        "deviation": 1.64,
+        "min": 31.19,
+        "max": 34.47,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 629.98,
+        "mean": 63,
+        "deviation": 3.15,
+        "min": 59.85,
+        "max": 66.15,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 254.17,
+        "mean": 25.42,
+        "deviation": 1.27,
+        "min": 24.15,
+        "max": 26.69,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/chacha20-encryption/zkm.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 329.87,
+        "mean": 32.99,
+        "deviation": 1.65,
+        "min": 31.34,
+        "max": 34.64,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 678.42,
+        "mean": 67.84,
+        "deviation": 3.39,
+        "min": 64.45,
+        "max": 71.23,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 244.28,
+        "mean": 24.43,
+        "deviation": 1.22,
+        "min": 23.21,
+        "max": 25.65,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/chacha20-encryption/zkwasm.json
+++ b/test/example-data/arm-laptop/chacha20-encryption/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 346.08,
+        "mean": 34.61,
+        "deviation": 1.73,
+        "min": 32.88,
+        "max": 36.34,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 715.24,
+        "mean": 71.52,
+        "deviation": 3.58,
+        "min": 67.94,
+        "max": 75.1,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 244.83,
+        "mean": 24.48,
+        "deviation": 1.22,
+        "min": 23.26,
+        "max": 25.7,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/jolt.json
+++ b/test/example-data/arm-laptop/ecc-addition/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 336.49,
+        "mean": 33.65,
+        "deviation": 1.68,
+        "min": 31.97,
+        "max": 35.33,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 660.44,
+        "mean": 66.04,
+        "deviation": 3.3,
+        "min": 62.74,
+        "max": 69.34,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 241.74,
+        "mean": 24.17,
+        "deviation": 1.21,
+        "min": 22.96,
+        "max": 25.38,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/nexus.json
+++ b/test/example-data/arm-laptop/ecc-addition/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 332.92,
+        "mean": 33.29,
+        "deviation": 1.66,
+        "min": 31.63,
+        "max": 34.95,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 628.89,
+        "mean": 62.89,
+        "deviation": 3.14,
+        "min": 59.75,
+        "max": 66.03,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 237.43,
+        "mean": 23.74,
+        "deviation": 1.19,
+        "min": 22.55,
+        "max": 24.93,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/risc0.json
+++ b/test/example-data/arm-laptop/ecc-addition/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 339.06,
+        "mean": 33.91,
+        "deviation": 1.7,
+        "min": 32.21,
+        "max": 35.61,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 697.91,
+        "mean": 69.79,
+        "deviation": 3.49,
+        "min": 66.3,
+        "max": 73.28,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 245.33,
+        "mean": 24.53,
+        "deviation": 1.23,
+        "min": 23.3,
+        "max": 25.76,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/sp1.json
+++ b/test/example-data/arm-laptop/ecc-addition/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 339.53,
+        "mean": 33.95,
+        "deviation": 1.7,
+        "min": 32.25,
+        "max": 35.65,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 659.98,
+        "mean": 66,
+        "deviation": 3.3,
+        "min": 62.7,
+        "max": 69.3,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 253.99,
+        "mean": 25.4,
+        "deviation": 1.27,
+        "min": 24.13,
+        "max": 26.67,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/zkm.json
+++ b/test/example-data/arm-laptop/ecc-addition/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 345.56,
+        "mean": 34.56,
+        "deviation": 1.73,
+        "min": 32.83,
+        "max": 36.29,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 695.61,
+        "mean": 69.56,
+        "deviation": 3.48,
+        "min": 66.08,
+        "max": 73.04,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 270.89,
+        "mean": 27.09,
+        "deviation": 1.35,
+        "min": 25.74,
+        "max": 28.44,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/ecc-addition/zkwasm.json
+++ b/test/example-data/arm-laptop/ecc-addition/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 343.58,
+        "mean": 34.36,
+        "deviation": 1.72,
+        "min": 32.64,
+        "max": 36.08,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 697.65,
+        "mean": 69.77,
+        "deviation": 3.49,
+        "min": 66.28,
+        "max": 73.26,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 275.6,
+        "mean": 27.56,
+        "deviation": 1.38,
+        "min": 26.18,
+        "max": 28.94,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/jolt.json
+++ b/test/example-data/arm-laptop/fft-transform/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 338.05,
+        "mean": 33.81,
+        "deviation": 1.69,
+        "min": 32.12,
+        "max": 35.5,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 648.84,
+        "mean": 64.88,
+        "deviation": 3.24,
+        "min": 61.64,
+        "max": 68.12,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 255.03,
+        "mean": 25.5,
+        "deviation": 1.28,
+        "min": 24.22,
+        "max": 26.78,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/nexus.json
+++ b/test/example-data/arm-laptop/fft-transform/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 357.45,
+        "mean": 35.75,
+        "deviation": 1.79,
+        "min": 33.96,
+        "max": 37.54,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 663.28,
+        "mean": 66.33,
+        "deviation": 3.32,
+        "min": 63.01,
+        "max": 69.65,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 265.49,
+        "mean": 26.55,
+        "deviation": 1.33,
+        "min": 25.22,
+        "max": 27.88,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/risc0.json
+++ b/test/example-data/arm-laptop/fft-transform/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 358.62,
+        "mean": 35.86,
+        "deviation": 1.79,
+        "min": 34.07,
+        "max": 37.65,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 709.22,
+        "mean": 70.92,
+        "deviation": 3.55,
+        "min": 67.37,
+        "max": 74.47,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 271.33,
+        "mean": 27.13,
+        "deviation": 1.36,
+        "min": 25.77,
+        "max": 28.49,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/sp1.json
+++ b/test/example-data/arm-laptop/fft-transform/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 368.81,
+        "mean": 36.88,
+        "deviation": 1.84,
+        "min": 35.04,
+        "max": 38.72,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 744,
+        "mean": 74.4,
+        "deviation": 3.72,
+        "min": 70.68,
+        "max": 78.12,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 267.22,
+        "mean": 26.72,
+        "deviation": 1.34,
+        "min": 25.38,
+        "max": 28.06,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/zkm.json
+++ b/test/example-data/arm-laptop/fft-transform/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 375.74,
+        "mean": 37.57,
+        "deviation": 1.88,
+        "min": 35.69,
+        "max": 39.45,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 743.21,
+        "mean": 74.32,
+        "deviation": 3.72,
+        "min": 70.6,
+        "max": 78.04,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 276.61,
+        "mean": 27.66,
+        "deviation": 1.38,
+        "min": 26.28,
+        "max": 29.04,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/fft-transform/zkwasm.json
+++ b/test/example-data/arm-laptop/fft-transform/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 352.05,
+        "mean": 35.2,
+        "deviation": 1.76,
+        "min": 33.44,
+        "max": 36.96,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 727.94,
+        "mean": 72.79,
+        "deviation": 3.64,
+        "min": 69.15,
+        "max": 76.43,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 287.78,
+        "mean": 28.78,
+        "deviation": 1.44,
+        "min": 27.34,
+        "max": 30.22,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/jolt.json
+++ b/test/example-data/arm-laptop/rsa-verification/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 331.57,
+        "mean": 33.16,
+        "deviation": 1.66,
+        "min": 31.5,
+        "max": 34.82,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 720.74,
+        "mean": 72.07,
+        "deviation": 3.6,
+        "min": 68.47,
+        "max": 75.67,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 269.58,
+        "mean": 26.96,
+        "deviation": 1.35,
+        "min": 25.61,
+        "max": 28.31,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/nexus.json
+++ b/test/example-data/arm-laptop/rsa-verification/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 342.45,
+        "mean": 34.24,
+        "deviation": 1.71,
+        "min": 32.53,
+        "max": 35.95,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 710.04,
+        "mean": 71,
+        "deviation": 3.55,
+        "min": 67.45,
+        "max": 74.55,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 272.42,
+        "mean": 27.24,
+        "deviation": 1.36,
+        "min": 25.88,
+        "max": 28.6,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/risc0.json
+++ b/test/example-data/arm-laptop/rsa-verification/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 355.59,
+        "mean": 35.56,
+        "deviation": 1.78,
+        "min": 33.78,
+        "max": 37.34,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 729.54,
+        "mean": 72.95,
+        "deviation": 3.65,
+        "min": 69.3,
+        "max": 76.6,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 265.07,
+        "mean": 26.51,
+        "deviation": 1.33,
+        "min": 25.18,
+        "max": 27.84,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/sp1.json
+++ b/test/example-data/arm-laptop/rsa-verification/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 369.09,
+        "mean": 36.91,
+        "deviation": 1.85,
+        "min": 35.06,
+        "max": 38.76,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 744.91,
+        "mean": 74.49,
+        "deviation": 3.72,
+        "min": 70.77,
+        "max": 78.21,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 277.88,
+        "mean": 27.79,
+        "deviation": 1.39,
+        "min": 26.4,
+        "max": 29.18,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/zkm.json
+++ b/test/example-data/arm-laptop/rsa-verification/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 388.62,
+        "mean": 38.86,
+        "deviation": 1.94,
+        "min": 36.92,
+        "max": 40.8,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 729.79,
+        "mean": 72.98,
+        "deviation": 3.65,
+        "min": 69.33,
+        "max": 76.63,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 272.87,
+        "mean": 27.29,
+        "deviation": 1.36,
+        "min": 25.93,
+        "max": 28.65,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/rsa-verification/zkwasm.json
+++ b/test/example-data/arm-laptop/rsa-verification/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 388.16,
+        "mean": 38.82,
+        "deviation": 1.94,
+        "min": 36.88,
+        "max": 40.76,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 781.54,
+        "mean": 78.15,
+        "deviation": 3.91,
+        "min": 74.24,
+        "max": 82.06,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 298.84,
+        "mean": 29.88,
+        "deviation": 1.49,
+        "min": 28.39,
+        "max": 31.37,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/jolt.json
+++ b/test/example-data/arm-laptop/sha3-hash/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 300.91,
+        "mean": 30.09,
+        "deviation": 1.5,
+        "min": 28.59,
+        "max": 31.59,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 623.92,
+        "mean": 62.39,
+        "deviation": 3.12,
+        "min": 59.27,
+        "max": 65.51,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 228.57,
+        "mean": 22.86,
+        "deviation": 1.14,
+        "min": 21.72,
+        "max": 24,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/nexus.json
+++ b/test/example-data/arm-laptop/sha3-hash/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 313.21,
+        "mean": 31.32,
+        "deviation": 1.57,
+        "min": 29.75,
+        "max": 32.89,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 589.39,
+        "mean": 58.94,
+        "deviation": 2.95,
+        "min": 55.99,
+        "max": 61.89,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 228.82,
+        "mean": 22.88,
+        "deviation": 1.14,
+        "min": 21.74,
+        "max": 24.02,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/risc0.json
+++ b/test/example-data/arm-laptop/sha3-hash/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 318.16,
+        "mean": 31.82,
+        "deviation": 1.59,
+        "min": 30.23,
+        "max": 33.41,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 596.95,
+        "mean": 59.69,
+        "deviation": 2.98,
+        "min": 56.71,
+        "max": 62.67,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 227.62,
+        "mean": 22.76,
+        "deviation": 1.14,
+        "min": 21.62,
+        "max": 23.9,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/sp1.json
+++ b/test/example-data/arm-laptop/sha3-hash/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 324.71,
+        "mean": 32.47,
+        "deviation": 1.62,
+        "min": 30.85,
+        "max": 34.09,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 646.25,
+        "mean": 64.62,
+        "deviation": 3.23,
+        "min": 61.39,
+        "max": 67.85,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 244.76,
+        "mean": 24.48,
+        "deviation": 1.22,
+        "min": 23.26,
+        "max": 25.7,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/zkm.json
+++ b/test/example-data/arm-laptop/sha3-hash/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 312.07,
+        "mean": 31.21,
+        "deviation": 1.56,
+        "min": 29.65,
+        "max": 32.77,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 621.24,
+        "mean": 62.12,
+        "deviation": 3.11,
+        "min": 59.01,
+        "max": 65.23,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 232.97,
+        "mean": 23.3,
+        "deviation": 1.16,
+        "min": 22.14,
+        "max": 24.46,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/arm-laptop/sha3-hash/zkwasm.json
+++ b/test/example-data/arm-laptop/sha3-hash/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 320.7,
+        "mean": 32.07,
+        "deviation": 1.6,
+        "min": 30.47,
+        "max": 33.67,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 649.47,
+        "mean": 64.95,
+        "deviation": 3.25,
+        "min": 61.7,
+        "max": 68.2,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 247.52,
+        "mean": 24.75,
+        "deviation": 1.24,
+        "min": 23.51,
+        "max": 25.99,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Apple M1",
+        "cores": 8,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "LPDDR4",
+      "size": 17179869184,
+      "speed": 4266
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "Apple M1 GPU",
+        "cores": 8,
+        "speed": 3200
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/jolt.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 206.2,
+        "mean": 20.62,
+        "deviation": 1.03,
+        "min": 19.59,
+        "max": 21.65,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 422.51,
+        "mean": 42.25,
+        "deviation": 2.11,
+        "min": 40.14,
+        "max": 44.36,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 151.55,
+        "mean": 15.15,
+        "deviation": 0.76,
+        "min": 14.39,
+        "max": 15.91,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/nexus.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 203.26,
+        "mean": 20.33,
+        "deviation": 1.02,
+        "min": 19.31,
+        "max": 21.35,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 405.81,
+        "mean": 40.58,
+        "deviation": 2.03,
+        "min": 38.55,
+        "max": 42.61,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 155.64,
+        "mean": 15.56,
+        "deviation": 0.78,
+        "min": 14.78,
+        "max": 16.34,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/risc0.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 224.92,
+        "mean": 22.49,
+        "deviation": 1.12,
+        "min": 21.37,
+        "max": 23.61,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 453.67,
+        "mean": 45.37,
+        "deviation": 2.27,
+        "min": 43.1,
+        "max": 47.64,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 162.46,
+        "mean": 16.25,
+        "deviation": 0.81,
+        "min": 15.44,
+        "max": 17.06,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/sp1.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 230.15,
+        "mean": 23.01,
+        "deviation": 1.15,
+        "min": 21.86,
+        "max": 24.16,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 436.64,
+        "mean": 43.66,
+        "deviation": 2.18,
+        "min": 41.48,
+        "max": 45.84,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 170.61,
+        "mean": 17.06,
+        "deviation": 0.85,
+        "min": 16.21,
+        "max": 17.91,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/zkm.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 227.29,
+        "mean": 22.73,
+        "deviation": 1.14,
+        "min": 21.59,
+        "max": 23.87,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 428.28,
+        "mean": 42.83,
+        "deviation": 2.14,
+        "min": 40.69,
+        "max": 44.97,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 174.55,
+        "mean": 17.45,
+        "deviation": 0.87,
+        "min": 16.58,
+        "max": 18.32,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/chacha20-encryption/zkwasm.json
+++ b/test/example-data/cpu-gpu/chacha20-encryption/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 229.4,
+        "mean": 22.94,
+        "deviation": 1.15,
+        "min": 21.79,
+        "max": 24.09,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 458.57,
+        "mean": 45.86,
+        "deviation": 2.29,
+        "min": 43.57,
+        "max": 48.15,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 173.76,
+        "mean": 17.38,
+        "deviation": 0.87,
+        "min": 16.51,
+        "max": 18.25,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/jolt.json
+++ b/test/example-data/cpu-gpu/ecc-addition/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 207.43,
+        "mean": 20.74,
+        "deviation": 1.04,
+        "min": 19.7,
+        "max": 21.78,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 449.17,
+        "mean": 44.92,
+        "deviation": 2.25,
+        "min": 42.67,
+        "max": 47.17,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 163.97,
+        "mean": 16.4,
+        "deviation": 0.82,
+        "min": 15.58,
+        "max": 17.22,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/nexus.json
+++ b/test/example-data/cpu-gpu/ecc-addition/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 216.33,
+        "mean": 21.63,
+        "deviation": 1.08,
+        "min": 20.55,
+        "max": 22.71,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 425.71,
+        "mean": 42.57,
+        "deviation": 2.13,
+        "min": 40.44,
+        "max": 44.7,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 172.05,
+        "mean": 17.2,
+        "deviation": 0.86,
+        "min": 16.34,
+        "max": 18.06,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/risc0.json
+++ b/test/example-data/cpu-gpu/ecc-addition/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 220.99,
+        "mean": 22.1,
+        "deviation": 1.1,
+        "min": 21,
+        "max": 23.2,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 454.55,
+        "mean": 45.46,
+        "deviation": 2.27,
+        "min": 43.19,
+        "max": 47.73,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 175.78,
+        "mean": 17.58,
+        "deviation": 0.88,
+        "min": 16.7,
+        "max": 18.46,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/sp1.json
+++ b/test/example-data/cpu-gpu/ecc-addition/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 238.64,
+        "mean": 23.86,
+        "deviation": 1.19,
+        "min": 22.67,
+        "max": 25.05,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 457.53,
+        "mean": 45.75,
+        "deviation": 2.29,
+        "min": 43.46,
+        "max": 48.04,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 175.52,
+        "mean": 17.55,
+        "deviation": 0.88,
+        "min": 16.67,
+        "max": 18.43,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/zkm.json
+++ b/test/example-data/cpu-gpu/ecc-addition/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 236.96,
+        "mean": 23.7,
+        "deviation": 1.18,
+        "min": 22.52,
+        "max": 24.88,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 483.97,
+        "mean": 48.4,
+        "deviation": 2.42,
+        "min": 45.98,
+        "max": 50.82,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 172.65,
+        "mean": 17.26,
+        "deviation": 0.86,
+        "min": 16.4,
+        "max": 18.12,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/ecc-addition/zkwasm.json
+++ b/test/example-data/cpu-gpu/ecc-addition/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 244.28,
+        "mean": 24.43,
+        "deviation": 1.22,
+        "min": 23.21,
+        "max": 25.65,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 479.41,
+        "mean": 47.94,
+        "deviation": 2.4,
+        "min": 45.54,
+        "max": 50.34,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 185.83,
+        "mean": 18.58,
+        "deviation": 0.93,
+        "min": 17.65,
+        "max": 19.51,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/jolt.json
+++ b/test/example-data/cpu-gpu/fft-transform/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 222.9,
+        "mean": 22.29,
+        "deviation": 1.11,
+        "min": 21.18,
+        "max": 23.4,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 451.55,
+        "mean": 45.15,
+        "deviation": 2.26,
+        "min": 42.89,
+        "max": 47.41,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 160.03,
+        "mean": 16,
+        "deviation": 0.8,
+        "min": 15.2,
+        "max": 16.8,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/nexus.json
+++ b/test/example-data/cpu-gpu/fft-transform/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 226.17,
+        "mean": 22.62,
+        "deviation": 1.13,
+        "min": 21.49,
+        "max": 23.75,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 468.42,
+        "mean": 46.84,
+        "deviation": 2.34,
+        "min": 44.5,
+        "max": 49.18,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 169.9,
+        "mean": 16.99,
+        "deviation": 0.85,
+        "min": 16.14,
+        "max": 17.84,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/risc0.json
+++ b/test/example-data/cpu-gpu/fft-transform/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 243.19,
+        "mean": 24.32,
+        "deviation": 1.22,
+        "min": 23.1,
+        "max": 25.54,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 461.58,
+        "mean": 46.16,
+        "deviation": 2.31,
+        "min": 43.85,
+        "max": 48.47,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 169.95,
+        "mean": 17,
+        "deviation": 0.85,
+        "min": 16.15,
+        "max": 17.85,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/sp1.json
+++ b/test/example-data/cpu-gpu/fft-transform/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 228.47,
+        "mean": 22.85,
+        "deviation": 1.14,
+        "min": 21.71,
+        "max": 23.99,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 489.75,
+        "mean": 48.98,
+        "deviation": 2.45,
+        "min": 46.53,
+        "max": 51.43,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 171.3,
+        "mean": 17.13,
+        "deviation": 0.86,
+        "min": 16.27,
+        "max": 17.99,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/zkm.json
+++ b/test/example-data/cpu-gpu/fft-transform/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 248.07,
+        "mean": 24.81,
+        "deviation": 1.24,
+        "min": 23.57,
+        "max": 26.05,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 501,
+        "mean": 50.1,
+        "deviation": 2.5,
+        "min": 47.6,
+        "max": 52.6,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 183.64,
+        "mean": 18.36,
+        "deviation": 0.92,
+        "min": 17.44,
+        "max": 19.28,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/fft-transform/zkwasm.json
+++ b/test/example-data/cpu-gpu/fft-transform/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 239.94,
+        "mean": 23.99,
+        "deviation": 1.2,
+        "min": 22.79,
+        "max": 25.19,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 480.12,
+        "mean": 48.01,
+        "deviation": 2.4,
+        "min": 45.61,
+        "max": 50.41,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 184.34,
+        "mean": 18.43,
+        "deviation": 0.92,
+        "min": 17.51,
+        "max": 19.35,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/jolt.json
+++ b/test/example-data/cpu-gpu/rsa-verification/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 227.78,
+        "mean": 22.78,
+        "deviation": 1.14,
+        "min": 21.64,
+        "max": 23.92,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 468.18,
+        "mean": 46.82,
+        "deviation": 2.34,
+        "min": 44.48,
+        "max": 49.16,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 169.07,
+        "mean": 16.91,
+        "deviation": 0.85,
+        "min": 16.06,
+        "max": 17.76,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/nexus.json
+++ b/test/example-data/cpu-gpu/rsa-verification/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 243.92,
+        "mean": 24.39,
+        "deviation": 1.22,
+        "min": 23.17,
+        "max": 25.61,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 458.27,
+        "mean": 45.83,
+        "deviation": 2.29,
+        "min": 43.54,
+        "max": 48.12,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 171.99,
+        "mean": 17.2,
+        "deviation": 0.86,
+        "min": 16.34,
+        "max": 18.06,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/risc0.json
+++ b/test/example-data/cpu-gpu/rsa-verification/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 236.94,
+        "mean": 23.69,
+        "deviation": 1.18,
+        "min": 22.51,
+        "max": 24.87,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 503.41,
+        "mean": 50.34,
+        "deviation": 2.52,
+        "min": 47.82,
+        "max": 52.86,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 188.8,
+        "mean": 18.88,
+        "deviation": 0.94,
+        "min": 17.94,
+        "max": 19.82,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/sp1.json
+++ b/test/example-data/cpu-gpu/rsa-verification/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 241.2,
+        "mean": 24.12,
+        "deviation": 1.21,
+        "min": 22.91,
+        "max": 25.33,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 478.84,
+        "mean": 47.88,
+        "deviation": 2.39,
+        "min": 45.49,
+        "max": 50.27,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 189.57,
+        "mean": 18.96,
+        "deviation": 0.95,
+        "min": 18.01,
+        "max": 19.91,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/zkm.json
+++ b/test/example-data/cpu-gpu/rsa-verification/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 243.63,
+        "mean": 24.36,
+        "deviation": 1.22,
+        "min": 23.14,
+        "max": 25.58,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 522.5,
+        "mean": 52.25,
+        "deviation": 2.61,
+        "min": 49.64,
+        "max": 54.86,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 179.12,
+        "mean": 17.91,
+        "deviation": 0.9,
+        "min": 17.01,
+        "max": 18.81,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/rsa-verification/zkwasm.json
+++ b/test/example-data/cpu-gpu/rsa-verification/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 254.26,
+        "mean": 25.43,
+        "deviation": 1.27,
+        "min": 24.16,
+        "max": 26.7,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 499.42,
+        "mean": 49.94,
+        "deviation": 2.5,
+        "min": 47.44,
+        "max": 52.44,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 186.65,
+        "mean": 18.66,
+        "deviation": 0.93,
+        "min": 17.73,
+        "max": 19.59,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/jolt.json
+++ b/test/example-data/cpu-gpu/sha3-hash/jolt.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 190.26,
+        "mean": 19.03,
+        "deviation": 0.95,
+        "min": 18.08,
+        "max": 19.98,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 413.99,
+        "mean": 41.4,
+        "deviation": 2.07,
+        "min": 39.33,
+        "max": 43.47,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 148.17,
+        "mean": 14.82,
+        "deviation": 0.74,
+        "min": 14.08,
+        "max": 15.56,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/nexus.json
+++ b/test/example-data/cpu-gpu/sha3-hash/nexus.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 207.09,
+        "mean": 20.71,
+        "deviation": 1.04,
+        "min": 19.67,
+        "max": 21.75,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 393.46,
+        "mean": 39.35,
+        "deviation": 1.97,
+        "min": 37.38,
+        "max": 41.32,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 156.58,
+        "mean": 15.66,
+        "deviation": 0.78,
+        "min": 14.88,
+        "max": 16.44,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/risc0.json
+++ b/test/example-data/cpu-gpu/sha3-hash/risc0.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 204.38,
+        "mean": 20.44,
+        "deviation": 1.02,
+        "min": 19.42,
+        "max": 21.46,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 420.09,
+        "mean": 42.01,
+        "deviation": 2.1,
+        "min": 39.91,
+        "max": 44.11,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 159.35,
+        "mean": 15.94,
+        "deviation": 0.8,
+        "min": 15.14,
+        "max": 16.74,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/sp1.json
+++ b/test/example-data/cpu-gpu/sha3-hash/sp1.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 218.86,
+        "mean": 21.89,
+        "deviation": 1.09,
+        "min": 20.8,
+        "max": 22.98,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 415.76,
+        "mean": 41.58,
+        "deviation": 2.08,
+        "min": 39.5,
+        "max": 43.66,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 166.26,
+        "mean": 16.63,
+        "deviation": 0.83,
+        "min": 15.8,
+        "max": 17.46,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/zkm.json
+++ b/test/example-data/cpu-gpu/sha3-hash/zkm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 220.19,
+        "mean": 22.02,
+        "deviation": 1.1,
+        "min": 20.92,
+        "max": 23.12,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 414.76,
+        "mean": 41.48,
+        "deviation": 2.07,
+        "min": 39.41,
+        "max": 43.55,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 156.48,
+        "mean": 15.65,
+        "deviation": 0.78,
+        "min": 14.87,
+        "max": 16.43,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/cpu-gpu/sha3-hash/zkwasm.json
+++ b/test/example-data/cpu-gpu/sha3-hash/zkwasm.json
@@ -1,0 +1,63 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 229.9,
+        "mean": 22.99,
+        "deviation": 1.15,
+        "min": 21.84,
+        "max": 24.14,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 437.03,
+        "mean": 43.7,
+        "deviation": 2.19,
+        "min": 41.51,
+        "max": 45.89,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 172.26,
+        "mean": 17.23,
+        "deviation": 0.86,
+        "min": 16.37,
+        "max": 18.09,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon W-1290",
+        "cores": 10,
+        "speed": 3.2
+      }
+    ],
+    "memory": {
+      "model": "G.Skill Ripjaws",
+      "size": 34359738368,
+      "speed": 3600
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA RTX 3080",
+        "cores": 8704,
+        "speed": 1710
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/jolt.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/jolt.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 188.69,
+        "mean": 18.87,
+        "deviation": 0.94,
+        "min": 17.93,
+        "max": 19.81,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 370.13,
+        "mean": 37.01,
+        "deviation": 1.85,
+        "min": 35.16,
+        "max": 38.86,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 130.93,
+        "mean": 13.09,
+        "deviation": 0.65,
+        "min": 12.44,
+        "max": 13.74,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/nexus.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/nexus.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 188.7,
+        "mean": 18.87,
+        "deviation": 0.94,
+        "min": 17.93,
+        "max": 19.81,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 359.17,
+        "mean": 35.92,
+        "deviation": 1.8,
+        "min": 34.12,
+        "max": 37.72,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 132.52,
+        "mean": 13.25,
+        "deviation": 0.66,
+        "min": 12.59,
+        "max": 13.91,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/risc0.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/risc0.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 186.35,
+        "mean": 18.64,
+        "deviation": 0.93,
+        "min": 17.71,
+        "max": 19.57,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 359.93,
+        "mean": 35.99,
+        "deviation": 1.8,
+        "min": 34.19,
+        "max": 37.79,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 138.47,
+        "mean": 13.85,
+        "deviation": 0.69,
+        "min": 13.16,
+        "max": 14.54,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/sp1.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/sp1.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 198.71,
+        "mean": 19.87,
+        "deviation": 0.99,
+        "min": 18.88,
+        "max": 20.86,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 394.89,
+        "mean": 39.49,
+        "deviation": 1.97,
+        "min": 37.52,
+        "max": 41.46,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 147.57,
+        "mean": 14.76,
+        "deviation": 0.74,
+        "min": 14.02,
+        "max": 15.5,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/zkm.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/zkm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 196.84,
+        "mean": 19.68,
+        "deviation": 0.98,
+        "min": 18.7,
+        "max": 20.66,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 382.81,
+        "mean": 38.28,
+        "deviation": 1.91,
+        "min": 36.37,
+        "max": 40.19,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 144,
+        "mean": 14.4,
+        "deviation": 0.72,
+        "min": 13.68,
+        "max": 15.12,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/chacha20-encryption/zkwasm.json
+++ b/test/example-data/hpc-cluster/chacha20-encryption/zkwasm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 202.01,
+        "mean": 20.2,
+        "deviation": 1.01,
+        "min": 19.19,
+        "max": 21.21,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 383.28,
+        "mean": 38.33,
+        "deviation": 1.92,
+        "min": 36.41,
+        "max": 40.25,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 143.93,
+        "mean": 14.39,
+        "deviation": 0.72,
+        "min": 13.67,
+        "max": 15.11,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/jolt.json
+++ b/test/example-data/hpc-cluster/ecc-addition/jolt.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 181.57,
+        "mean": 18.16,
+        "deviation": 0.91,
+        "min": 17.25,
+        "max": 19.07,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 381.44,
+        "mean": 38.14,
+        "deviation": 1.91,
+        "min": 36.23,
+        "max": 40.05,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 145.5,
+        "mean": 14.55,
+        "deviation": 0.73,
+        "min": 13.82,
+        "max": 15.28,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/nexus.json
+++ b/test/example-data/hpc-cluster/ecc-addition/nexus.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 200.23,
+        "mean": 20.02,
+        "deviation": 1,
+        "min": 19.02,
+        "max": 21.02,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 374.73,
+        "mean": 37.47,
+        "deviation": 1.87,
+        "min": 35.6,
+        "max": 39.34,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 139.23,
+        "mean": 13.92,
+        "deviation": 0.7,
+        "min": 13.22,
+        "max": 14.62,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/risc0.json
+++ b/test/example-data/hpc-cluster/ecc-addition/risc0.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 195.65,
+        "mean": 19.57,
+        "deviation": 0.98,
+        "min": 18.59,
+        "max": 20.55,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 374.55,
+        "mean": 37.46,
+        "deviation": 1.87,
+        "min": 35.59,
+        "max": 39.33,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 153.32,
+        "mean": 15.33,
+        "deviation": 0.77,
+        "min": 14.56,
+        "max": 16.1,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/sp1.json
+++ b/test/example-data/hpc-cluster/ecc-addition/sp1.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 204.53,
+        "mean": 20.45,
+        "deviation": 1.02,
+        "min": 19.43,
+        "max": 21.47,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 413.71,
+        "mean": 41.37,
+        "deviation": 2.07,
+        "min": 39.3,
+        "max": 43.44,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 149.5,
+        "mean": 14.95,
+        "deviation": 0.75,
+        "min": 14.2,
+        "max": 15.7,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/zkm.json
+++ b/test/example-data/hpc-cluster/ecc-addition/zkm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 210.7,
+        "mean": 21.07,
+        "deviation": 1.05,
+        "min": 20.02,
+        "max": 22.12,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 407.58,
+        "mean": 40.76,
+        "deviation": 2.04,
+        "min": 38.72,
+        "max": 42.8,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 149.89,
+        "mean": 14.99,
+        "deviation": 0.75,
+        "min": 14.24,
+        "max": 15.74,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/ecc-addition/zkwasm.json
+++ b/test/example-data/hpc-cluster/ecc-addition/zkwasm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 208.28,
+        "mean": 20.83,
+        "deviation": 1.04,
+        "min": 19.79,
+        "max": 21.87,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 436.14,
+        "mean": 43.61,
+        "deviation": 2.18,
+        "min": 41.43,
+        "max": 45.79,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 155.97,
+        "mean": 15.6,
+        "deviation": 0.78,
+        "min": 14.82,
+        "max": 16.38,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/jolt.json
+++ b/test/example-data/hpc-cluster/fft-transform/jolt.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 198.48,
+        "mean": 19.85,
+        "deviation": 0.99,
+        "min": 18.86,
+        "max": 20.84,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 376.33,
+        "mean": 37.63,
+        "deviation": 1.88,
+        "min": 35.75,
+        "max": 39.51,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 146.84,
+        "mean": 14.68,
+        "deviation": 0.73,
+        "min": 13.95,
+        "max": 15.41,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/nexus.json
+++ b/test/example-data/hpc-cluster/fft-transform/nexus.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 203.25,
+        "mean": 20.32,
+        "deviation": 1.02,
+        "min": 19.3,
+        "max": 21.34,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 402.94,
+        "mean": 40.29,
+        "deviation": 2.01,
+        "min": 38.28,
+        "max": 42.3,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 147.18,
+        "mean": 14.72,
+        "deviation": 0.74,
+        "min": 13.98,
+        "max": 15.46,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/risc0.json
+++ b/test/example-data/hpc-cluster/fft-transform/risc0.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 205.37,
+        "mean": 20.54,
+        "deviation": 1.03,
+        "min": 19.51,
+        "max": 21.57,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 417.35,
+        "mean": 41.74,
+        "deviation": 2.09,
+        "min": 39.65,
+        "max": 43.83,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 146.09,
+        "mean": 14.61,
+        "deviation": 0.73,
+        "min": 13.88,
+        "max": 15.34,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/sp1.json
+++ b/test/example-data/hpc-cluster/fft-transform/sp1.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 218.08,
+        "mean": 21.81,
+        "deviation": 1.09,
+        "min": 20.72,
+        "max": 22.9,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 413.5,
+        "mean": 41.35,
+        "deviation": 2.07,
+        "min": 39.28,
+        "max": 43.42,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 156.3,
+        "mean": 15.63,
+        "deviation": 0.78,
+        "min": 14.85,
+        "max": 16.41,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/zkm.json
+++ b/test/example-data/hpc-cluster/fft-transform/zkm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 212.52,
+        "mean": 21.25,
+        "deviation": 1.06,
+        "min": 20.19,
+        "max": 22.31,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 417.37,
+        "mean": 41.74,
+        "deviation": 2.09,
+        "min": 39.65,
+        "max": 43.83,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 159.21,
+        "mean": 15.92,
+        "deviation": 0.8,
+        "min": 15.12,
+        "max": 16.72,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/fft-transform/zkwasm.json
+++ b/test/example-data/hpc-cluster/fft-transform/zkwasm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 205.72,
+        "mean": 20.57,
+        "deviation": 1.03,
+        "min": 19.54,
+        "max": 21.6,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 426.28,
+        "mean": 42.63,
+        "deviation": 2.13,
+        "min": 40.5,
+        "max": 44.76,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 169.42,
+        "mean": 16.94,
+        "deviation": 0.85,
+        "min": 16.09,
+        "max": 17.79,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/jolt.json
+++ b/test/example-data/hpc-cluster/rsa-verification/jolt.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 195.36,
+        "mean": 19.54,
+        "deviation": 0.98,
+        "min": 18.56,
+        "max": 20.52,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 393,
+        "mean": 39.3,
+        "deviation": 1.96,
+        "min": 37.34,
+        "max": 41.26,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 150.68,
+        "mean": 15.07,
+        "deviation": 0.75,
+        "min": 14.32,
+        "max": 15.82,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/nexus.json
+++ b/test/example-data/hpc-cluster/rsa-verification/nexus.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 214.8,
+        "mean": 21.48,
+        "deviation": 1.07,
+        "min": 20.41,
+        "max": 22.55,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 412.96,
+        "mean": 41.3,
+        "deviation": 2.06,
+        "min": 39.24,
+        "max": 43.36,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 158.41,
+        "mean": 15.84,
+        "deviation": 0.79,
+        "min": 15.05,
+        "max": 16.63,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/risc0.json
+++ b/test/example-data/hpc-cluster/rsa-verification/risc0.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 200.78,
+        "mean": 20.08,
+        "deviation": 1,
+        "min": 19.08,
+        "max": 21.08,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 442.98,
+        "mean": 44.3,
+        "deviation": 2.21,
+        "min": 42.09,
+        "max": 46.51,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 162.85,
+        "mean": 16.28,
+        "deviation": 0.81,
+        "min": 15.47,
+        "max": 17.09,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/sp1.json
+++ b/test/example-data/hpc-cluster/rsa-verification/sp1.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 218.68,
+        "mean": 21.87,
+        "deviation": 1.09,
+        "min": 20.78,
+        "max": 22.96,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 432.21,
+        "mean": 43.22,
+        "deviation": 2.16,
+        "min": 41.06,
+        "max": 45.38,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 154.59,
+        "mean": 15.46,
+        "deviation": 0.77,
+        "min": 14.69,
+        "max": 16.23,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/zkm.json
+++ b/test/example-data/hpc-cluster/rsa-verification/zkm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 213.29,
+        "mean": 21.33,
+        "deviation": 1.07,
+        "min": 20.26,
+        "max": 22.4,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 422.86,
+        "mean": 42.29,
+        "deviation": 2.11,
+        "min": 40.18,
+        "max": 44.4,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 159.41,
+        "mean": 15.94,
+        "deviation": 0.8,
+        "min": 15.14,
+        "max": 16.74,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/rsa-verification/zkwasm.json
+++ b/test/example-data/hpc-cluster/rsa-verification/zkwasm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 221.56,
+        "mean": 22.16,
+        "deviation": 1.11,
+        "min": 21.05,
+        "max": 23.27,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 461.05,
+        "mean": 46.1,
+        "deviation": 2.31,
+        "min": 43.79,
+        "max": 48.41,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 159.83,
+        "mean": 15.98,
+        "deviation": 0.8,
+        "min": 15.18,
+        "max": 16.78,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/jolt.json
+++ b/test/example-data/hpc-cluster/sha3-hash/jolt.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 174.32,
+        "mean": 17.43,
+        "deviation": 0.87,
+        "min": 16.56,
+        "max": 18.3,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 340.07,
+        "mean": 34.01,
+        "deviation": 1.7,
+        "min": 32.31,
+        "max": 35.71,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 137.48,
+        "mean": 13.75,
+        "deviation": 0.69,
+        "min": 13.06,
+        "max": 14.44,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/nexus.json
+++ b/test/example-data/hpc-cluster/sha3-hash/nexus.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 185.58,
+        "mean": 18.56,
+        "deviation": 0.93,
+        "min": 17.63,
+        "max": 19.49,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 365.51,
+        "mean": 36.55,
+        "deviation": 1.83,
+        "min": 34.72,
+        "max": 38.38,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 134.1,
+        "mean": 13.41,
+        "deviation": 0.67,
+        "min": 12.74,
+        "max": 14.08,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/risc0.json
+++ b/test/example-data/hpc-cluster/sha3-hash/risc0.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 184.2,
+        "mean": 18.42,
+        "deviation": 0.92,
+        "min": 17.5,
+        "max": 19.34,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 363.96,
+        "mean": 36.4,
+        "deviation": 1.82,
+        "min": 34.58,
+        "max": 38.22,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 133.72,
+        "mean": 13.37,
+        "deviation": 0.67,
+        "min": 12.7,
+        "max": 14.04,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/sp1.json
+++ b/test/example-data/hpc-cluster/sha3-hash/sp1.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 183.48,
+        "mean": 18.35,
+        "deviation": 0.92,
+        "min": 17.43,
+        "max": 19.27,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 366.72,
+        "mean": 36.67,
+        "deviation": 1.83,
+        "min": 34.84,
+        "max": 38.5,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 143.56,
+        "mean": 14.36,
+        "deviation": 0.72,
+        "min": 13.64,
+        "max": 15.08,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/zkm.json
+++ b/test/example-data/hpc-cluster/sha3-hash/zkm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 181.02,
+        "mean": 18.1,
+        "deviation": 0.91,
+        "min": 17.19,
+        "max": 19.01,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 372.91,
+        "mean": 37.29,
+        "deviation": 1.86,
+        "min": 35.43,
+        "max": 39.15,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 136.9,
+        "mean": 13.69,
+        "deviation": 0.68,
+        "min": 13.01,
+        "max": 14.37,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/hpc-cluster/sha3-hash/zkwasm.json
+++ b/test/example-data/hpc-cluster/sha3-hash/zkwasm.json
@@ -1,0 +1,68 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 196.66,
+        "mean": 19.67,
+        "deviation": 0.98,
+        "min": 18.69,
+        "max": 20.65,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 398.46,
+        "mean": 39.85,
+        "deviation": 1.99,
+        "min": 37.86,
+        "max": 41.84,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 144.82,
+        "mean": 14.48,
+        "deviation": 0.72,
+        "min": 13.76,
+        "max": 15.2,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      },
+      {
+        "model": "Intel Xeon Platinum 8368",
+        "cores": 38,
+        "speed": 2.4
+      }
+    ],
+    "memory": {
+      "model": "Kingston ECC",
+      "size": 137438953472,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [
+      {
+        "model": "NVIDIA A100",
+        "cores": 6912,
+        "speed": 1410
+      }
+    ],
+    "accelerated": true
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/jolt.json
+++ b/test/example-data/single-cpu/chacha20-encryption/jolt.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 262.95,
+        "mean": 26.29,
+        "deviation": 1.31,
+        "min": 24.98,
+        "max": 27.6,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 510.93,
+        "mean": 51.09,
+        "deviation": 2.55,
+        "min": 48.54,
+        "max": 53.64,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 197.55,
+        "mean": 19.75,
+        "deviation": 0.99,
+        "min": 18.76,
+        "max": 20.74,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/nexus.json
+++ b/test/example-data/single-cpu/chacha20-encryption/nexus.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 274.73,
+        "mean": 27.47,
+        "deviation": 1.37,
+        "min": 26.1,
+        "max": 28.84,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 528.75,
+        "mean": 52.87,
+        "deviation": 2.64,
+        "min": 50.23,
+        "max": 55.51,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 195.19,
+        "mean": 19.52,
+        "deviation": 0.98,
+        "min": 18.54,
+        "max": 20.5,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/risc0.json
+++ b/test/example-data/single-cpu/chacha20-encryption/risc0.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 279.46,
+        "mean": 27.95,
+        "deviation": 1.4,
+        "min": 26.55,
+        "max": 29.35,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 556.26,
+        "mean": 55.63,
+        "deviation": 2.78,
+        "min": 52.85,
+        "max": 58.41,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 206.76,
+        "mean": 20.68,
+        "deviation": 1.03,
+        "min": 19.65,
+        "max": 21.71,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/sp1.json
+++ b/test/example-data/single-cpu/chacha20-encryption/sp1.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 273.97,
+        "mean": 27.4,
+        "deviation": 1.37,
+        "min": 26.03,
+        "max": 28.77,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 567.91,
+        "mean": 56.79,
+        "deviation": 2.84,
+        "min": 53.95,
+        "max": 59.63,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 205.67,
+        "mean": 20.57,
+        "deviation": 1.03,
+        "min": 19.54,
+        "max": 21.6,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/zkm.json
+++ b/test/example-data/single-cpu/chacha20-encryption/zkm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 283,
+        "mean": 28.3,
+        "deviation": 1.42,
+        "min": 26.88,
+        "max": 29.72,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 540.67,
+        "mean": 54.07,
+        "deviation": 2.7,
+        "min": 51.37,
+        "max": 56.77,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 211.21,
+        "mean": 21.12,
+        "deviation": 1.06,
+        "min": 20.06,
+        "max": 22.18,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/chacha20-encryption/zkwasm.json
+++ b/test/example-data/single-cpu/chacha20-encryption/zkwasm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "chacha20-encryption",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 279.35,
+        "mean": 27.93,
+        "deviation": 1.4,
+        "min": 26.53,
+        "max": 29.33,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 547.15,
+        "mean": 54.71,
+        "deviation": 2.74,
+        "min": 51.97,
+        "max": 57.45,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 203.87,
+        "mean": 20.39,
+        "deviation": 1.02,
+        "min": 19.37,
+        "max": 21.41,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/jolt.json
+++ b/test/example-data/single-cpu/ecc-addition/jolt.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 261.32,
+        "mean": 26.13,
+        "deviation": 1.31,
+        "min": 24.82,
+        "max": 27.44,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 519.73,
+        "mean": 51.97,
+        "deviation": 2.6,
+        "min": 49.37,
+        "max": 54.57,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 198.57,
+        "mean": 19.86,
+        "deviation": 0.99,
+        "min": 18.87,
+        "max": 20.85,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/nexus.json
+++ b/test/example-data/single-cpu/ecc-addition/nexus.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 264.18,
+        "mean": 26.42,
+        "deviation": 1.32,
+        "min": 25.1,
+        "max": 27.74,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 537.68,
+        "mean": 53.77,
+        "deviation": 2.69,
+        "min": 51.08,
+        "max": 56.46,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 215.78,
+        "mean": 21.58,
+        "deviation": 1.08,
+        "min": 20.5,
+        "max": 22.66,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/risc0.json
+++ b/test/example-data/single-cpu/ecc-addition/risc0.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 275.45,
+        "mean": 27.55,
+        "deviation": 1.38,
+        "min": 26.17,
+        "max": 28.93,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 549.83,
+        "mean": 54.98,
+        "deviation": 2.75,
+        "min": 52.23,
+        "max": 57.73,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 217.21,
+        "mean": 21.72,
+        "deviation": 1.09,
+        "min": 20.63,
+        "max": 22.81,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/sp1.json
+++ b/test/example-data/single-cpu/ecc-addition/sp1.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 286.06,
+        "mean": 28.61,
+        "deviation": 1.43,
+        "min": 27.18,
+        "max": 30.04,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 597.88,
+        "mean": 59.79,
+        "deviation": 2.99,
+        "min": 56.8,
+        "max": 62.78,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 212.61,
+        "mean": 21.26,
+        "deviation": 1.06,
+        "min": 20.2,
+        "max": 22.32,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/zkm.json
+++ b/test/example-data/single-cpu/ecc-addition/zkm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 291.56,
+        "mean": 29.16,
+        "deviation": 1.46,
+        "min": 27.7,
+        "max": 30.62,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 586.75,
+        "mean": 58.68,
+        "deviation": 2.93,
+        "min": 55.75,
+        "max": 61.61,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 219.33,
+        "mean": 21.93,
+        "deviation": 1.1,
+        "min": 20.83,
+        "max": 23.03,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/ecc-addition/zkwasm.json
+++ b/test/example-data/single-cpu/ecc-addition/zkwasm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "ecc-addition",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 289.58,
+        "mean": 28.96,
+        "deviation": 1.45,
+        "min": 27.51,
+        "max": 30.41,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 568.93,
+        "mean": 56.89,
+        "deviation": 2.84,
+        "min": 54.05,
+        "max": 59.73,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 225.23,
+        "mean": 22.52,
+        "deviation": 1.13,
+        "min": 21.39,
+        "max": 23.65,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/jolt.json
+++ b/test/example-data/single-cpu/fft-transform/jolt.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 270.6,
+        "mean": 27.06,
+        "deviation": 1.35,
+        "min": 25.71,
+        "max": 28.41,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 537.43,
+        "mean": 53.74,
+        "deviation": 2.69,
+        "min": 51.05,
+        "max": 56.43,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 216.15,
+        "mean": 21.62,
+        "deviation": 1.08,
+        "min": 20.54,
+        "max": 22.7,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/nexus.json
+++ b/test/example-data/single-cpu/fft-transform/nexus.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 298.43,
+        "mean": 29.84,
+        "deviation": 1.49,
+        "min": 28.35,
+        "max": 31.33,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 549.81,
+        "mean": 54.98,
+        "deviation": 2.75,
+        "min": 52.23,
+        "max": 57.73,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 211.67,
+        "mean": 21.17,
+        "deviation": 1.06,
+        "min": 20.11,
+        "max": 22.23,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/risc0.json
+++ b/test/example-data/single-cpu/fft-transform/risc0.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 280.5,
+        "mean": 28.05,
+        "deviation": 1.4,
+        "min": 26.65,
+        "max": 29.45,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 603.16,
+        "mean": 60.32,
+        "deviation": 3.02,
+        "min": 57.3,
+        "max": 63.34,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 225.49,
+        "mean": 22.55,
+        "deviation": 1.13,
+        "min": 21.42,
+        "max": 23.68,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/sp1.json
+++ b/test/example-data/single-cpu/fft-transform/sp1.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 307.4,
+        "mean": 30.74,
+        "deviation": 1.54,
+        "min": 29.2,
+        "max": 32.28,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 583.68,
+        "mean": 58.37,
+        "deviation": 2.92,
+        "min": 55.45,
+        "max": 61.29,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 221.11,
+        "mean": 22.11,
+        "deviation": 1.11,
+        "min": 21,
+        "max": 23.22,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/zkm.json
+++ b/test/example-data/single-cpu/fft-transform/zkm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 303.48,
+        "mean": 30.35,
+        "deviation": 1.52,
+        "min": 28.83,
+        "max": 31.87,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 624.56,
+        "mean": 62.46,
+        "deviation": 3.12,
+        "min": 59.34,
+        "max": 65.58,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 216.51,
+        "mean": 21.65,
+        "deviation": 1.08,
+        "min": 20.57,
+        "max": 22.73,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/fft-transform/zkwasm.json
+++ b/test/example-data/single-cpu/fft-transform/zkwasm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "fft-transform",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 297.63,
+        "mean": 29.76,
+        "deviation": 1.49,
+        "min": 28.27,
+        "max": 31.25,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 630.73,
+        "mean": 63.07,
+        "deviation": 3.15,
+        "min": 59.92,
+        "max": 66.22,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 237.08,
+        "mean": 23.71,
+        "deviation": 1.19,
+        "min": 22.52,
+        "max": 24.9,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/jolt.json
+++ b/test/example-data/single-cpu/rsa-verification/jolt.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 303.06,
+        "mean": 30.31,
+        "deviation": 1.52,
+        "min": 28.79,
+        "max": 31.83,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 605.59,
+        "mean": 60.56,
+        "deviation": 3.03,
+        "min": 57.53,
+        "max": 63.59,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 227.84,
+        "mean": 22.78,
+        "deviation": 1.14,
+        "min": 21.64,
+        "max": 23.92,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/nexus.json
+++ b/test/example-data/single-cpu/rsa-verification/nexus.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 310.51,
+        "mean": 31.05,
+        "deviation": 1.55,
+        "min": 29.5,
+        "max": 32.6,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 587.77,
+        "mean": 58.78,
+        "deviation": 2.94,
+        "min": 55.84,
+        "max": 61.72,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 231.83,
+        "mean": 23.18,
+        "deviation": 1.16,
+        "min": 22.02,
+        "max": 24.34,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/risc0.json
+++ b/test/example-data/single-cpu/rsa-verification/risc0.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 312.62,
+        "mean": 31.26,
+        "deviation": 1.56,
+        "min": 29.7,
+        "max": 32.82,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 607.5,
+        "mean": 60.75,
+        "deviation": 3.04,
+        "min": 57.71,
+        "max": 63.79,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 222.11,
+        "mean": 22.21,
+        "deviation": 1.11,
+        "min": 21.1,
+        "max": 23.32,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/sp1.json
+++ b/test/example-data/single-cpu/rsa-verification/sp1.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 309.76,
+        "mean": 30.98,
+        "deviation": 1.55,
+        "min": 29.43,
+        "max": 32.53,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 641.27,
+        "mean": 64.13,
+        "deviation": 3.21,
+        "min": 60.92,
+        "max": 67.34,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 239.69,
+        "mean": 23.97,
+        "deviation": 1.2,
+        "min": 22.77,
+        "max": 25.17,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/zkm.json
+++ b/test/example-data/single-cpu/rsa-verification/zkm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 321.86,
+        "mean": 32.19,
+        "deviation": 1.61,
+        "min": 30.58,
+        "max": 33.8,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 603.34,
+        "mean": 60.33,
+        "deviation": 3.02,
+        "min": 57.31,
+        "max": 63.35,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 243.37,
+        "mean": 24.34,
+        "deviation": 1.22,
+        "min": 23.12,
+        "max": 25.56,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/rsa-verification/zkwasm.json
+++ b/test/example-data/single-cpu/rsa-verification/zkwasm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "rsa-verification",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 315.31,
+        "mean": 31.53,
+        "deviation": 1.58,
+        "min": 29.95,
+        "max": 33.11,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 615.27,
+        "mean": 61.53,
+        "deviation": 3.08,
+        "min": 58.45,
+        "max": 64.61,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 241.32,
+        "mean": 24.13,
+        "deviation": 1.21,
+        "min": 22.92,
+        "max": 25.34,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/jolt.json
+++ b/test/example-data/single-cpu/sha3-hash/jolt.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "jolt",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 250.63,
+        "mean": 25.06,
+        "deviation": 1.25,
+        "min": 23.81,
+        "max": 26.31,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 487.31,
+        "mean": 48.73,
+        "deviation": 2.44,
+        "min": 46.29,
+        "max": 51.17,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 188.86,
+        "mean": 18.89,
+        "deviation": 0.94,
+        "min": 17.95,
+        "max": 19.83,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/nexus.json
+++ b/test/example-data/single-cpu/sha3-hash/nexus.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "nexus",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 250.35,
+        "mean": 25.04,
+        "deviation": 1.25,
+        "min": 23.79,
+        "max": 26.29,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 491.27,
+        "mean": 49.13,
+        "deviation": 2.46,
+        "min": 46.67,
+        "max": 51.59,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 188.31,
+        "mean": 18.83,
+        "deviation": 0.94,
+        "min": 17.89,
+        "max": 19.77,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/risc0.json
+++ b/test/example-data/single-cpu/sha3-hash/risc0.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "risc0",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 249.62,
+        "mean": 24.96,
+        "deviation": 1.25,
+        "min": 23.71,
+        "max": 26.21,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 519.29,
+        "mean": 51.93,
+        "deviation": 2.6,
+        "min": 49.33,
+        "max": 54.53,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 195.5,
+        "mean": 19.55,
+        "deviation": 0.98,
+        "min": 18.57,
+        "max": 20.53,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/sp1.json
+++ b/test/example-data/single-cpu/sha3-hash/sp1.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "sp1",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 268.46,
+        "mean": 26.85,
+        "deviation": 1.34,
+        "min": 25.51,
+        "max": 28.19,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 520.05,
+        "mean": 52,
+        "deviation": 2.6,
+        "min": 49.4,
+        "max": 54.6,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 192.8,
+        "mean": 19.28,
+        "deviation": 0.96,
+        "min": 18.32,
+        "max": 20.24,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/zkm.json
+++ b/test/example-data/single-cpu/sha3-hash/zkm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 258.01,
+        "mean": 25.8,
+        "deviation": 1.29,
+        "min": 24.51,
+        "max": 27.09,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 545.5,
+        "mean": 54.55,
+        "deviation": 2.73,
+        "min": 51.82,
+        "max": 57.28,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 203.43,
+        "mean": 20.34,
+        "deviation": 1.02,
+        "min": 19.32,
+        "max": 21.36,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}

--- a/test/example-data/single-cpu/sha3-hash/zkwasm.json
+++ b/test/example-data/single-cpu/sha3-hash/zkwasm.json
@@ -1,0 +1,57 @@
+{
+  "toolchain": "zkwasm",
+  "benchmarks": [
+    {
+      "name": "sha3-hash",
+      "compile": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 286.27,
+        "mean": 28.63,
+        "deviation": 1.43,
+        "min": 27.2,
+        "max": 30.06,
+        "memory": 536870912,
+        "size": 1000000
+      },
+      "prove": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 555.98,
+        "mean": 55.6,
+        "deviation": 2.78,
+        "min": 52.82,
+        "max": 58.38,
+        "memory": 1073741824,
+        "size": 1200000
+      },
+      "verify": {
+        "timeStarted": "2025-06-01T12:00:00Z",
+        "runs": 10,
+        "totalDuration": 205.03,
+        "mean": 20.5,
+        "deviation": 1.03,
+        "min": 19.47,
+        "max": 21.53,
+        "memory": 268435456,
+        "size": 1200000
+      }
+    }
+  ],
+  "hardware": {
+    "cpu": [
+      {
+        "model": "Intel Core i7-9700K",
+        "cores": 8,
+        "speed": 3.6
+      }
+    ],
+    "memory": {
+      "model": "Corsair Vengeance",
+      "size": 17179869184,
+      "speed": 3200
+    },
+    "hardwareAcceleration": [],
+    "accelerated": false
+  }
+}


### PR DESCRIPTION
## Summary
- add `gen-example-data` just target
- extend example data generator with `--skip-existing`
- support five new benchmarks
- generate JSON results for the new benchmarks

## Testing
- `node --test test`

------
https://chatgpt.com/codex/tasks/task_e_68415f3f8b008329953118fafd6ca82a